### PR TITLE
minimize comment, mark as abuse via graphql

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -141,18 +141,18 @@ jobs:
                 Write-Host "Minimizing comment id: $commentId"
 
                   $mutation =@"
-            mutation {
-                __typename
-                minimizeComment(
-                    input: {
-                        subjectId: "$commentId",
-                        classifier: ABUSE
-                    }
-                ) {
-                    clientMutationId
-                }
-            }
-            "@
+          mutation {
+              __typename
+              minimizeComment(
+                  input: {
+                      subjectId: "$commentId",
+                      classifier: ABUSE
+                  }
+              ) {
+                  clientMutationId
+              }
+          }
+          "@
 
                 $payload = @{
                     query=$mutation

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -110,13 +110,6 @@ jobs:
 
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
-            try {
-              Write-Host "Trying to get comment id"
-              $commentId = $content.commentId
-            } catch {
-              Write-Host "Failed to get comment id"
-              $commentId = $null
-            }
             Write-Host "This is comment id: $commentId"
               if ($commentId) {
                 Write-Host "Minimizing comment"
@@ -152,7 +145,7 @@ jobs:
                 Write-Host "No comment id to minimize"
               }
 
-            if ($anger -ge 2 -and $offensive -ge 2) {
+            if ($anger -ge 8 -and $offensive -ge 8) {
               Write-Host "Anger/Offense condition reached"
               $commentToPost = "${{ inputs.commentToPost }}"
               if ($commentToPost) {
@@ -172,82 +165,11 @@ jobs:
                 }
               }
 
-              Write-Host "This is comment id: $commentId"
-              if ($commentId) {
-                Write-Host "Minimizing comment"
-
-                $mutation =@"
-          mutation {
-              __typename
-              minimizeComment(
-                  input: {
-                      subjectId: "$($commentId)",
-                      classifier: ABUSE
-                  }
-              ) {
-                  clientMutationId
-              }
-          }
-          "@
-
-                $payload = @{
-                    query=$mutation
-                }
-
-                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-                $headers.Add("content-type","application/json")
-                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
-
-                $body = ConvertTo-Json $payload
-                $url = "https://api.github.com/graphql"
-                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
-
-                Write-Host "Minimized comment"
-              } else {
-                Write-Host "No comment id to minimize"
-              }
-
               if (!$commentToPost -and !$labelToAdd) {
                 Write-Host "Neither 'commentToPost' nor 'labelToAdd' was set, so not notifying anybody"
               }
             } else {
               Write-Host "Comment is OK"
-              # this is where check if a comment id is set, if so call minimize comment here
-              Write-Host "This is comment id:"
-          $commentId
-              if ($commentId) {
-                Write-Host "Minimizing comment"
-
-                $mutation =@"
-          mutation {
-              __typename
-              minimizeComment(
-                  input: {
-                      subjectId: "$($commentId)",
-                      classifier: ABUSE
-                  }
-              ) {
-                  clientMutationId
-              }
-          }
-          "@
-
-                $payload = @{
-                    query=$mutation
-                }
-
-                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-                $headers.Add("content-type","application/json")
-                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
-
-                $body = ConvertTo-Json $payload
-                $url = "https://api.github.com/graphql"
-                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
-
-                Write-Host "Minimized comment"
-              } else {
-                Write-Host "No comment id to minimize"
-              }
             }
           } else {
             Write-Host "We got nothing :("

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -29,13 +29,13 @@ on:
 
 jobs:
   comments:
-    uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@dev/haritha/min-comment
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
     steps:
       - name: comment if offensive or angry
+        uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@dev/haritha/min-comment
         shell: pwsh
         continue-on-error: true
         env:

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -111,6 +111,7 @@ jobs:
             Write-Host "Offensive: $offensive"
 
             if ($anger -ge 2 -and $offensive -ge 2) {
+              Write-Host "Anger/Offense condition reached"
               $commentToPost = "${{ inputs.commentToPost }}"
               if ($commentToPost) {
                 if ($isPr) {
@@ -166,6 +167,8 @@ jobs:
                 $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
 
                 Write-Host "Minimized comment"
+              } else {
+                Write-Host "No comment id to minimize"
               }
             } else {
               Write-Host "Comment is OK"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -139,6 +139,7 @@ jobs:
               $body = ConvertTo-Json $payload
               $url = "https://api.github.com/graphql"
               $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
+              $response | Out-String | Write-Host
 
               Write-Host "Minimized comment"
             } else {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -34,8 +34,6 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: checkout code
-        uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@dev/haritha/min-comment
       - name: comment if offensive or angry
         shell: pwsh
         continue-on-error: true

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -110,9 +110,8 @@ jobs:
 
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
-            Write-Host "This is comment id: $commentId"
             if ($commentId) {
-              Write-Host "Minimizing comment"
+              Write-Host "Minimizing comment id: $commentId"
 
                 $mutation =@"
           mutation {
@@ -146,7 +145,7 @@ jobs:
               Write-Host "No comment id to minimize"
             }
 
-            if ($anger -ge 3 -and $offensive -ge 3) {
+            if ($anger -ge 7 -and $offensive -ge 7) {
               Write-Host "Anger/Offense condition reached"
               $commentToPost = "${{ inputs.commentToPost }}"
               if ($commentToPost) {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -110,7 +110,7 @@ jobs:
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
 
-            if ($anger -ge 7 -and $offensive -ge 7) {
+            if ($anger -ge 2 -and $offensive -ge 2) {
               $commentToPost = "${{ inputs.commentToPost }}"
               if ($commentToPost) {
                 if ($isPr) {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -110,6 +110,42 @@ jobs:
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
 
+            Write-Host "This is comment id:"
+          $commentId
+              if ($commentId) {
+                Write-Host "Minimizing comment"
+
+                $mutation =@"
+          mutation {
+              __typename
+              minimizeComment(
+                  input: {
+                      subjectId: "$($commentId)",
+                      classifier: ABUSE
+                  }
+              ) {
+                  clientMutationId
+              }
+          }
+          "@
+
+                $payload = @{
+                    query=$mutation
+                }
+
+                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+                $headers.Add("content-type","application/json")
+                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
+
+                $body = ConvertTo-Json $payload
+                $url = "https://api.github.com/graphql"
+                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
+
+                Write-Host "Minimized comment"
+              } else {
+                Write-Host "No comment id to minimize"
+              }
+
             if ($anger -ge 2 -and $offensive -ge 2) {
               Write-Host "Anger/Offense condition reached"
               $commentToPost = "${{ inputs.commentToPost }}"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -29,6 +29,7 @@ on:
 
 jobs:
   comments:
+    uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@dev/haritha/min-comment
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -115,6 +115,7 @@ jobs:
 
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
+            Write-Host "Minimizing comment id: $commentId"
             if ($commentId -and $minimizeComment -eq $true) {
               Write-Host "Minimizing comment id: $commentId"
 

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -116,6 +116,7 @@ jobs:
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
             Write-Host "Minimizing comment id: $commentId"
+            $minimizeComment = "${{ inputs.minimizeComment }}"
             if ($commentId -and $minimizeComment -eq $true) {
               Write-Host "Minimizing comment id: $commentId"
 

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -116,8 +116,7 @@ jobs:
               Write-Host "Failed to get comment id"
               $commentId = $null
             }
-            Write-Host "This is comment id:"
-          $commentId
+            Write-Host "This is comment id: $commentId"
               if ($commentId) {
                 Write-Host "Minimizing comment"
 
@@ -172,8 +171,7 @@ jobs:
                 }
               }
 
-              Write-Host "This is comment id:"
-          $commentId
+              Write-Host "This is comment id: $commentId"
               if ($commentId) {
                 Write-Host "Minimizing comment"
 

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -119,7 +119,7 @@ jobs:
               __typename
               minimizeComment(
                   input: {
-                      subjectId: "$($commentId)",
+                      subjectId: "$commentId",
                       classifier: ABUSE
                   }
               ) {
@@ -139,7 +139,7 @@ jobs:
               $body = ConvertTo-Json $payload
               $url = "https://api.github.com/graphql"
               $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
-              $response | ConvertTo-Json | Write-Host
+              $response | ConvertTo-Json -Compress | Write-Host
 
               Write-Host "Minimized comment"
             } else {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -60,6 +60,7 @@ jobs:
               title = ""
               body = $github.event.comment.body
             }
+            $commentId = $github.event.comment.id
             $number = $github.event.pull_request.number
             $isPr = true
             Write-Host "There was a review comment on a pull request."
@@ -68,6 +69,7 @@ jobs:
               title = ""
               body = $github.event.comment.body
             }
+            $commentId = $github.event.comment.id
             $number = $github.event.issue.number
             $isPr = false
             Write-Host "There was a comment on an issue or pull request."
@@ -129,6 +131,39 @@ jobs:
 
               if (!$commentToPost -and !$labelToAdd) {
                 Write-Host "Neither 'commentToPost' nor 'labelToAdd' was set, so not notifying anybody"
+              }
+
+              # this is where check if a comment id is set, if so call minimize comment here
+              if ($commentId) {
+                Write-Host "Minimizing comment"
+
+                $mutation =@"
+                      mutation {
+                          __typename
+                          minimizeComment(
+                              input: {
+                                  subjectId: "$($commentId)",
+                                  classifier: ABUSE
+                              }
+                          ) {
+                              clientMutationId
+                          }
+                      }
+                "@
+
+                $payload = @{
+                    query=$mutation
+                }
+
+                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+                $headers.Add("content-type","application/json")
+                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
+
+                $body = ConvertTo-Json $payload
+                $url = "https://api.github.com/graphql"
+                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
+
+                Write-Host "Minimized comment"
               }
             } else {
               Write-Host "Comment is OK"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -138,18 +138,18 @@ jobs:
                 Write-Host "Minimizing comment"
 
                 $mutation =@"
-                      mutation {
-                          __typename
-                          minimizeComment(
-                              input: {
-                                  subjectId: "$($commentId)",
-                                  classifier: ABUSE
-                              }
-                          ) {
-                              clientMutationId
-                          }
-                      }
-                "@
+          mutation {
+              __typename
+              minimizeComment(
+                  input: {
+                      subjectId: "$($commentId)",
+                      classifier: ABUSE
+                  }
+              ) {
+                  clientMutationId
+              }
+          }
+          "@
 
                 $payload = @{
                     query=$mutation

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -133,7 +133,8 @@ jobs:
               if (!$commentToPost -and !$labelToAdd) {
                 Write-Host "Neither 'commentToPost' nor 'labelToAdd' was set, so not notifying anybody"
               }
-
+            } else {
+              Write-Host "Comment is OK"
               # this is where check if a comment id is set, if so call minimize comment here
               Write-Host "This is comment id:"
           $commentId
@@ -170,8 +171,6 @@ jobs:
               } else {
                 Write-Host "No comment id to minimize"
               }
-            } else {
-              Write-Host "Comment is OK"
             }
           } else {
             Write-Host "We got nothing :("

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -111,8 +111,8 @@ jobs:
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
             Write-Host "This is comment id: $commentId"
-              if ($commentId) {
-                Write-Host "Minimizing comment"
+            if ($commentId) {
+              Write-Host "Minimizing comment"
 
                 $mutation =@"
           mutation {
@@ -128,22 +128,22 @@ jobs:
           }
           "@
 
-                $payload = @{
-                    query=$mutation
-                }
-
-                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-                $headers.Add("content-type","application/json")
-                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
-
-                $body = ConvertTo-Json $payload
-                $url = "https://api.github.com/graphql"
-                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
-
-                Write-Host "Minimized comment"
-              } else {
-                Write-Host "No comment id to minimize"
+              $payload = @{
+                  query=$mutation
               }
+
+              $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+              $headers.Add("content-type","application/json")
+              $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
+
+              $body = ConvertTo-Json $payload
+              $url = "https://api.github.com/graphql"
+              $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
+
+              Write-Host "Minimized comment"
+            } else {
+              Write-Host "No comment id to minimize"
+            }
 
             if ($anger -ge 3 -and $offensive -ge 3) {
               Write-Host "Anger/Offense condition reached"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -28,7 +28,7 @@ on:
         type: string
       minimizeComment:
         description: "Opt in to minimizing a comment on the issue or pull request if it's getting heated."
-        default: ""
+        default: false
         required: false
         type: boolean
 

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -134,6 +134,8 @@ jobs:
               }
 
               # this is where check if a comment id is set, if so call minimize comment here
+              Write-Host "This is comment id:"
+          $comment
               if ($commentId) {
                 Write-Host "Minimizing comment"
 

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -145,7 +145,7 @@ jobs:
                 Write-Host "No comment id to minimize"
               }
 
-            if ($anger -ge 8 -and $offensive -ge 8) {
+            if ($anger -ge 7 -and $offensive -ge 7) {
               Write-Host "Anger/Offense condition reached"
               $commentToPost = "${{ inputs.commentToPost }}"
               if ($commentToPost) {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -153,6 +153,7 @@ jobs:
                 }
             }
             "@
+
                 $payload = @{
                     query=$mutation
                 }

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -115,42 +115,6 @@ jobs:
 
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
-            Write-Host "Minimizing comment id: $commentId"
-            $minimizeComment = "${{ inputs.minimizeComment }}"
-            if ($commentId -and $minimizeComment -eq $true) {
-              Write-Host "Minimizing comment id: $commentId"
-
-                $mutation =@"
-          mutation {
-              __typename
-              minimizeComment(
-                  input: {
-                      subjectId: "$commentId",
-                      classifier: ABUSE
-                  }
-              ) {
-                  clientMutationId
-              }
-          }
-          "@
-
-              $payload = @{
-                  query=$mutation
-              }
-
-              $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-              $headers.Add("content-type","application/json")
-              $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
-
-              $body = ConvertTo-Json $payload
-              $url = "https://api.github.com/graphql"
-              $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
-              $response | ConvertTo-Json -Compress | Write-Host
-
-              Write-Host "Minimized comment"
-            } else {
-              Write-Host "No comment id to minimize"
-            }
 
             if ($anger -ge 7 -and $offensive -ge 7) {
               Write-Host "Anger/Offense condition reached"
@@ -170,6 +134,41 @@ jobs:
                 } else {
                   & gh issue edit "$number" --add-label "$labelToAdd" --repo "${{ github.repository }}"
                 }
+              }
+
+              $minimizeComment = "${{ inputs.minimizeComment }}"
+              if ($commentId -and $minimizeComment -eq $true) {
+                Write-Host "Minimizing comment id: $commentId"
+                  $mutation =@"
+            mutation {
+                __typename
+                minimizeComment(
+                    input: {
+                        subjectId: "$commentId",
+                        classifier: ABUSE
+                    }
+                ) {
+                    clientMutationId
+                }
+            }
+            "@
+
+                $payload = @{
+                    query=$mutation
+                }
+
+                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+                $headers.Add("content-type","application/json")
+                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
+
+                $body = ConvertTo-Json $payload
+                $url = "https://api.github.com/graphql"
+                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
+                $response | ConvertTo-Json -Compress | Write-Host
+
+                Write-Host "Minimized comment"
+              } else {
+                Write-Host "No comment id to minimize"
               }
 
               if (!$commentToPost -and !$labelToAdd) {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -34,8 +34,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: comment if offensive or angry
+      - name: checkout code
         uses: jonathanpeppers/inclusive-heat-sensor/.github/workflows/comments.yml@dev/haritha/min-comment
+      - name: comment if offensive or angry
         shell: pwsh
         continue-on-error: true
         env:

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -109,7 +109,13 @@ jobs:
 
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
-
+            try {
+              Write-Host "Trying to get comment id"
+              $commentId = $content.commentId
+            } catch {
+              Write-Host "Failed to get comment id"
+              $commentId = $null
+            }
             Write-Host "This is comment id:"
           $commentId
               if ($commentId) {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -139,6 +139,7 @@ jobs:
               $minimizeComment = "${{ inputs.minimizeComment }}"
               if ($commentId -and $minimizeComment -eq $true) {
                 Write-Host "Minimizing comment id: $commentId"
+
                   $mutation =@"
             mutation {
                 __typename
@@ -152,7 +153,6 @@ jobs:
                 }
             }
             "@
-
                 $payload = @{
                     query=$mutation
                 }

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -130,6 +130,42 @@ jobs:
                 }
               }
 
+              Write-Host "This is comment id:"
+          $commentId
+              if ($commentId) {
+                Write-Host "Minimizing comment"
+
+                $mutation =@"
+          mutation {
+              __typename
+              minimizeComment(
+                  input: {
+                      subjectId: "$($commentId)",
+                      classifier: ABUSE
+                  }
+              ) {
+                  clientMutationId
+              }
+          }
+          "@
+
+                $payload = @{
+                    query=$mutation
+                }
+
+                $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+                $headers.Add("content-type","application/json")
+                $headers.Add("Authorization","bearer $Env:GITHUB_TOKEN")
+
+                $body = ConvertTo-Json $payload
+                $url = "https://api.github.com/graphql"
+                $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
+
+                Write-Host "Minimized comment"
+              } else {
+                Write-Host "No comment id to minimize"
+              }
+
               if (!$commentToPost -and !$labelToAdd) {
                 Write-Host "Neither 'commentToPost' nor 'labelToAdd' was set, so not notifying anybody"
               }

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -135,7 +135,7 @@ jobs:
 
               # this is where check if a comment id is set, if so call minimize comment here
               Write-Host "This is comment id:"
-          $comment
+          $commentId
               if ($commentId) {
                 Write-Host "Minimizing comment"
 

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -145,7 +145,7 @@ jobs:
                 Write-Host "No comment id to minimize"
               }
 
-            if ($anger -ge 7 -and $offensive -ge 7) {
+            if ($anger -ge 3 -and $offensive -ge 3) {
               Write-Host "Anger/Offense condition reached"
               $commentToPost = "${{ inputs.commentToPost }}"
               if ($commentToPost) {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -26,6 +26,11 @@ on:
         default: "https://icr-heat-sensor.wus3.sample-dev.azgrafana-test.io/api/HeatSensor"
         required: false
         type: string
+      minimizeComment:
+        description: "Opt in to minimizing a comment on the issue or pull request if it's getting heated."
+        default: ""
+        required: false
+        type: boolean
 
 jobs:
   comments:
@@ -110,7 +115,7 @@ jobs:
 
             Write-Host "Anger: $anger"
             Write-Host "Offensive: $offensive"
-            if ($commentId) {
+            if ($commentId -and $minimizeComment -eq $true) {
               Write-Host "Minimizing comment id: $commentId"
 
                 $mutation =@"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -61,7 +61,7 @@ jobs:
               title = ""
               body = $github.event.comment.body
             }
-            $commentId = $github.event.comment.id
+            $commentId = $github.event.comment.node_id
             $number = $github.event.pull_request.number
             $isPr = true
             Write-Host "There was a review comment on a pull request."
@@ -70,7 +70,7 @@ jobs:
               title = ""
               body = $github.event.comment.body
             }
-            $commentId = $github.event.comment.id
+            $commentId = $github.event.comment.node_id
             $number = $github.event.issue.number
             $isPr = false
             Write-Host "There was a comment on an issue or pull request."

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -139,7 +139,7 @@ jobs:
               $body = ConvertTo-Json $payload
               $url = "https://api.github.com/graphql"
               $response= Invoke-RestMethod -Uri $url -Headers $headers -Method "POST" -Body $body
-              $response | Out-String | Write-Host
+              $response | ConvertTo-Json | Write-Host
 
               Write-Host "Minimized comment"
             } else {

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -48,6 +48,7 @@ jobs:
           Write-Host "$Env:GITHUB_CONTEXT"
 
           $isPr = true
+          $commentId = ""
           if ($github.event_name -eq "pull_request") {
             $data = @{
               title = $github.event.pull_request.title;


### PR DESCRIPTION
leveraging the existing [REST](https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28) call, we can get the specific comment id of interest from comment object in the payload.

then, via the [GraphQL API](https://docs.github.com/en/graphql/reference/mutations#minimizecomment), we can minimize the comment and mark it as abuse. don't think the client mutation id is necessary for this call..

fixes https://github.com/jonathanpeppers/inclusive-heat-sensor/issues/11