### PR TITLE
[action] step should always succeed

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - name: comment if offensive or angry
         shell: pwsh
+        continue-on-error: true
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-heat-sensor/issues/17

We saw during the test of this action on the dotnet/maui repo:

1. Someone comments on a PR

2. The action runs and fails

3. The commenter gets an email/notification?!?

Let's mark the step `continue-on-error`, to hopefully prevent this.

I still think we should figure out the failing error code and fix that, but this should be additional safety.