### PR TITLE
[service] OpenAI `content_filter` / 400

### DIFF
--- a/Inclusive.HeatSensor.Services/LLMClient.cs
+++ b/Inclusive.HeatSensor.Services/LLMClient.cs
@@ -85,7 +85,7 @@ public class LLMClient
             _logger.LogInformation("Exception from OpenAI: {ex}", ex);
             if (ex.Message.Contains("content_filter", StringComparison.OrdinalIgnoreCase))
             {
-                return new Rating { Offensive = 10, Anger = 10, Url = url };
+                return new Rating { Offensive = -1, Anger = -1, Url = url };
             }
             else
             {


### PR DESCRIPTION
We found a comment such as this triggered OpenAI's content filter:

    Body: this is broken in `8.0.90`

It thought the combination of "body" and "broken" was violent...

For now, let's mark these as -1 offensive and anger, as we have no idea for this text.