### PR TITLE
[action] remove `Title:` and `Body:` from request

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -117,7 +117,7 @@ jobs:
           }
 
           $body = @{
-            comment = "Title: $($data.title) `nBody:`n$($data.body)"
+            comment = "$($data.title)`n$($data.body)"
             url = $url
           }
           $bodyJson = $body | ConvertTo-Json -Compress


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-heat-sensor/pull/29

As seen in #29, the word "Body:" can throw off the LLM.

Let's remove these and just include the text with a line break after the title.