### PR TITLE
[service] fix logging for `url`

### DIFF
--- a/Inclusive.HeatSensor.Web/Inclusive.HeatSensor.Web.http
+++ b/Inclusive.HeatSensor.Web/Inclusive.HeatSensor.Web.http
@@ -12,7 +12,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "comment": "this is a code review comment"
+  "comment": "this is a code review comment",
+  "url": "https://github.com/jonathanpeppers/inclusive-heat-sensor/issues/27#issuecomment-2465032570"
 }
 
 ### POST Request
@@ -21,5 +22,6 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "comment": "this code is very very ugly. We should stop doing it ASAP."
+  "comment": "this code is very very ugly. We should stop doing it ASAP.",
+  "url": "https://github.com/jonathanpeppers/inclusive-heat-sensor/issues/27#issuecomment-2465032570"
 }


### PR DESCRIPTION
The logging is not working, as it only prints:

    Rating: { "offensive": 2, "anger": 4 }

I made it set the `Url` property, prior to logging and returning the value.

With these changes, I can see:

![image](https://github.com/user-attachments/assets/20d8e43e-775a-4372-9d05-5da19fa20cee)

And the message in the log:

![image](https://github.com/user-attachments/assets/57fc80ac-60ff-46a0-8f0e-ceffd64f7631)