### PR TITLE
[actions] fix our `comments.yml` workload

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -17,5 +17,5 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: jonathanpeppers/inclusive-heat-sensor@dev/action
+      - uses: jonathanpeppers/inclusive-heat-sensor@main
         continue-on-error: true


### PR DESCRIPTION
I think it broke after merging/deleting the `dev/action` branch:

    Error: Unable to resolve action `jonathanpeppers/inclusive-heat-sensor@dev/action`, unable to find version `dev/action`